### PR TITLE
Handle quoted arguments in CLI calls

### DIFF
--- a/1password-lib.el
+++ b/1password-lib.el
@@ -28,7 +28,7 @@ output of the call to the 1Password CLI.  By default, this is
         (error (format "Unable to find 1Password CLI '%s'" 1password-executable)))
       (read-only-mode -1)
       (erase-buffer)
-      (apply #'call-process qualifed-executable nil 't  nil (cons "--no-color" (split-string args " ")))
+      (apply #'call-process qualifed-executable nil 't  nil (cons "--no-color" (split-string-and-unquote args " ")))
       (special-mode)
       (goto-char (point-min))
       (eval (list buffer-reader-fn)))))
@@ -56,7 +56,7 @@ output of the call to the 1Password CLI.  By default, this is
     (unless qualifed-executable
       (error (format "Unable to find 1Password CLI '%s'" 1password-executable)))
     (make-process :name "1password"
-                  :command (append (list 1password-executable "--no-color") (split-string args " "))
+                  :command (append (list 1password-executable "--no-color") (split-string-and-unquote args " "))
                   :filter filter-fn
                   :sentinel sentinel-fn)
     promise))


### PR DESCRIPTION
Replace `split-string` with `split-string-and-unquote` to correctly handle quoted arguments when invoking the 1Password CLI. This ensures proper parsing of arguments containing spaces or special characters.

This makes it possible to use `(auth-source-search :type '1password :host "\"Name of some 1pw login\"")` in addition to `id` and `url`.